### PR TITLE
Cleaning up old connections

### DIFF
--- a/examples/nostr-chat/index.html
+++ b/examples/nostr-chat/index.html
@@ -50,16 +50,20 @@
           sendBox    = document.querySelector('.send-box'),
           relayAddr  = document.querySelector('input[name="relayUrl"]')
 
+    let emitter = null
+
     if (!relayAddr.getAttribute('value')) relayAddr.setAttribute('value', DEFAULT_RELAY_URL)
 
     configForm.addEventListener('submit', async (e) => {
       e.preventDefault()
 
       let { relayUrl, topic, secret } = Object.fromEntries(new FormData(e.target))
+      let initialized = emitter !== null
       
       if (!topic) topic = 'general'
 
-      const emitter = new NostrEmitter()
+      if (initialized) await emitter.close()
+      emitter = new NostrEmitter()
 
       await emitter.connect(relayUrl, topic + secret)
 
@@ -73,12 +77,14 @@
         console.log(event, meta)
       })
 
-      sendBox.addEventListener('submit', (e) => {
-        e.preventDefault()
-        const { message } = Object.fromEntries(new FormData(e.target))
-        emitter.emit('chatmsg', { data: message })
-        clearInput()
-      })
+      if (!initialized) {
+        sendBox.addEventListener('submit', (e) => {
+          e.preventDefault()
+          const { message } = Object.fromEntries(new FormData(e.target))
+          emitter.emit('chatmsg', { data: message })
+          clearInput()
+        })
+      }
     })
 
     function post(name, msg) {

--- a/examples/nostr-chat/index.html
+++ b/examples/nostr-chat/index.html
@@ -62,7 +62,7 @@
       
       if (!topic) topic = 'general'
 
-      if (initialized) await emitter.close()
+      if (initialized) emitter.close()
       emitter = new NostrEmitter()
 
       await emitter.connect(relayUrl, topic + secret)

--- a/index.js
+++ b/index.js
@@ -283,11 +283,11 @@ class NostrEmitter {
     this.on(eventName, withinFn)
   }
 
-  emit(eventName, args, eventMsg) {
+  async emit(eventName, args, eventMsg) {
     /** Emit a series of arguments for the event, and
      *  present them to each subscriber in the list.
      * */
-    this.send(eventName, args, eventMsg)
+    await this.send(eventName, args, eventMsg)
   }
 
   remove(eventName, fn) {
@@ -295,8 +295,8 @@ class NostrEmitter {
     this._getFn(eventName).delete(fn)
   }
 
-  close() {
-    this.emit('close', this.id)
+  async close() {
+    await this.emit('close', this.id)
     this.socket.close()
     this.connected = false
     this.subscribed = false


### PR DESCRIPTION
Cleaning up the existing connection when the user hits 'Connect' again. It looks like there was a bug with the close() functionality trying to emit the 'close' message after the socket was closed. Fixed by making the entire chain of calls synchronous.